### PR TITLE
Configurable Memory in Oberon Emulator

### DIFF
--- a/Mods/Display.Mod
+++ b/Mods/Display.Mod
@@ -1,11 +1,10 @@
 MODULE Display;  (*NW 5.11.2013*)
-(* Adapted for a customizable framebuffer size -- see git history *)
+(* Adapted for a customizable framebuffer size and origin -- see git history *)
 
   IMPORT SYSTEM;
 
   CONST black* = 0; white* = 1;  (*black = background*)
     replace* = 0; paint* = 1; invert* = 2;  (*modes*)
-    base = 0E7F00H;  (*adr of 1024 x 768 pixel, monocolor display frame*)
 
   TYPE Frame* = POINTER TO FrameDesc;
     FrameMsg* = RECORD END ;
@@ -28,7 +27,7 @@ MODULE Display;  (*NW 5.11.2013*)
 
   PROCEDURE Dot*(col, x, y, mode: INTEGER);
     VAR a: INTEGER; u, s: SET;
-  BEGIN a := base + (x DIV 32)*4 + y*Span;
+  BEGIN a := Base + (x DIV 32)*4 + y*Span;
     s := {x MOD 32}; SYSTEM.GET(a, u);
     IF mode = paint THEN SYSTEM.PUT(a, u + s)
     ELSIF mode = invert THEN SYSTEM.PUT(a, u / s)
@@ -39,7 +38,7 @@ MODULE Display;  (*NW 5.11.2013*)
 
   PROCEDURE ReplConst*(col, x, y, w, h, mode: INTEGER);
     VAR al, ar, a0, a1, i: INTEGER; left, right, mid, pix, pixl, pixr: SET;
-  BEGIN al := base + y*Span;
+  BEGIN al := Base + y*Span;
     ar := ((x+w-1) DIV 32)*4 + al; al := (x DIV 32)*4 + al;
     IF ar = al THEN
       mid := {(x MOD 32) .. ((x+w-1) MOD 32)};
@@ -79,7 +78,7 @@ MODULE Display;  (*NW 5.11.2013*)
     VAR a0, pwd, i: INTEGER;
       w, h, pbt: BYTE; pix: SET;
   BEGIN SYSTEM.GET(patadr, w); SYSTEM.GET(patadr+1, h); INC(patadr, 2);
-    a0 := base + (x DIV 32)*4 + y*Span;
+    a0 := Base + (x DIV 32)*4 + y*Span;
     FOR i := 1 TO h DO
       (*build pattern line; w < 32*)
       SYSTEM.GET(patadr, pbt); INC(patadr); pwd := pbt;
@@ -111,7 +110,7 @@ MODULE Display;  (*NW 5.11.2013*)
   BEGIN
     u0 := sx DIV 32; u1 := sx MOD 32; u2 := (sx+w) DIV 32; u3 := (sx+w) MOD 32;
     v0 := dx DIV 32; v1 := dx MOD 32; v2 := (dx+w) DIV 32; v3 := (dx+w) MOD 32;
-    sa := base + u0*4 + sy*Span; da := base + v0*4 + dy*Span;
+    sa := Base + u0*4 + sy*Span; da := Base + v0*4 + dy*Span;
     d := da - sa; n := u1 - v1;   (*displacement in words and bits*)
     len := (u2 - u0) * 4;
     m0 := {v1 .. 31}; m2 := {v3 .. 31}; m3 := m0 / m2;
@@ -164,7 +163,7 @@ MODULE Display;  (*NW 5.11.2013*)
       pta0, pta1: INTEGER;  (*pattern addresses*)
       ph: BYTE;
       left, right, mid, pix, pixl, pixr, ptw: SET;
-  BEGIN al := base + y*Span; SYSTEM.GET(patadr+1, ph);
+  BEGIN al := Base + y*Span; SYSTEM.GET(patadr+1, ph);
     pta0 := patadr+4; pta1 := ph*4 + pta0;
     ar := ((x+w-1) DIV 32)*4 + al; al := (x DIV 32)*4 + al;
     IF ar = al THEN
@@ -192,21 +191,21 @@ MODULE Display;  (*NW 5.11.2013*)
   PROCEDURE InitResolution;
   VAR magic: INTEGER;
   BEGIN
-    SYSTEM.GET(base, magic);
+    SYSTEM.GET(Base, magic);
     IF magic = 53697A65H THEN
-      SYSTEM.GET(base + 4, Width);
-      SYSTEM.GET(base + 8, Height);
+      SYSTEM.GET(Base + 4, Width);
+      SYSTEM.GET(Base + 8, Height);
       Span := 128;
     ELSIF magic = 53697A66H THEN
-      SYSTEM.GET(base + 4, Width);
-      SYSTEM.GET(base + 8, Height);
+      SYSTEM.GET(Base + 4, Width);
+      SYSTEM.GET(Base + 8, Height);
       Span := Width DIV 8
     ELSE
       Width := 1024; Height := 768; Span := 128
     END;
   END InitResolution;
 
-BEGIN Base := base; InitResolution;
+BEGIN SYSTEM.GET(12,Base); INC(Base,16); InitResolution;
   arrow := SYSTEM.ADR($0F0F 0060 0070 0038 001C 000E 0007 8003 C101 E300 7700 3F00 1F00 3F00 7F00 FF00$);
   star := SYSTEM.ADR($0F0F 8000 8220 8410 8808 9004 A002 C001 7F7F C001 A002 9004 8808 8410 8220 8000$);
   hook := SYSTEM.ADR($0C0C 070F 8707 C703 E701 F700 7F00 3F00 1F00 0F00 0700 0300 01$);

--- a/src/risc.h
+++ b/src/risc.h
@@ -8,7 +8,9 @@
 // This is the standard size of the framebuffer, can be overridden.
 #define RISC_FRAMEBUFFER_WIDTH 1024
 #define RISC_FRAMEBUFFER_HEIGHT 768
-
+#define RISC_MEMTOTAL 0 //megabytes of emulated RISC memory including the framebuffer
+                        //0 means unmodified framebuffer start, 1.5MB of main memory
+                        //otherwise framebuffer is adjusted to the end of main memory
 struct RISC;
 
 struct Damage {
@@ -21,7 +23,7 @@ void risc_set_serial(struct RISC *risc, const struct RISC_Serial *serial);
 void risc_set_spi(struct RISC *risc, int index, const struct RISC_SPI *spi);
 void risc_set_clipboard(struct RISC *risc, const struct RISC_Clipboard *clipboard);
 void risc_set_switches(struct RISC *risc, int switches);
-void risc_screen_size_hack(struct RISC *risc, int width, int height);
+void risc_screen_and_mem_size_hack(struct RISC *risc, int width, int height, int memtotal);
 
 void risc_reset(struct RISC *risc);
 void risc_run(struct RISC *risc, int cycles);

--- a/src/sdl-main.c
+++ b/src/sdl-main.c
@@ -114,6 +114,7 @@ int main (int argc, char *argv[]) {
   const char *serial_in = NULL;
   const char *serial_out = NULL;
   bool boot_from_serial = false;
+  bool defaultMemoryAndVideo = true;  
 
   int opt;
   while ((opt = getopt_long(argc, argv, "z:fLs:I:O:S", long_options, NULL)) != -1) {
@@ -134,13 +135,18 @@ int main (int argc, char *argv[]) {
         break;
       }
       case 's': {
-        int w, h;
-        if (sscanf(optarg, "%dx%d", &w, &h) != 2) {
-          usage();
+        int m, w, h;
+        if (sscanf(optarg, "%dM%dx%d", &m, &w, &h) != 3) {
+          if (sscanf(optarg, "%dx%d", &w, &h) != 2) {
+            usage();
+          }else{
+	    m=0;
+	  }
         }
         risc_rect.w = clamp(w, 32, MAX_WIDTH) & ~31;
         risc_rect.h = clamp(h, 32, MAX_HEIGHT);
-        risc_screen_size_hack(risc, risc_rect.w, risc_rect.h);
+        risc_screen_and_mem_size_hack(risc, risc_rect.w, risc_rect.h, m);
+        defaultMemoryAndVideo = false;
         break;
       }
       case 'I': {
@@ -161,6 +167,12 @@ int main (int argc, char *argv[]) {
       }
     }
   }
+  if (defaultMemoryAndVideo) {
+    risc_screen_and_mem_size_hack(risc, RISC_FRAMEBUFFER_WIDTH, RISC_FRAMEBUFFER_HEIGHT, RISC_MEMTOTAL);
+  }
+
+  risc_reset(risc);
+
 
   if (optind == argc - 1) {
     risc_set_spi(risc, 1, disk_new(argv[optind]));


### PR DESCRIPTION
Here are some changes that allow the user to specify how much memory to give the risc emulator.
I modified the -s parameter to optionally allow memory to be specified, for example: 

./risc DISK.img -s 8M1280x1024

gives 8 megabytes to the emulator with the top of that memory reserved for a 1280x1024 monochrome display. Specifying '0M' or leaving the M value off gives the original behavior.

I also adapted the Display.Mod code to use a variable for the base of video memory instead of a constant. Display.Mod must be recompiled in the Oberon system before it will properly work in an expanded memory environment, of course.

These changes to oberon-risc-emu also patch the boot loader ROM on the fly with the new memory limit and stack origin parameters so the rest of the Oberon code requires no changes.

I hope you find these changes useful,

Best Regards,
Chuck
