### PR TITLE
Add raw serial support on Windows

### DIFF
--- a/src/raw-serial.c
+++ b/src/raw-serial.c
@@ -1,10 +1,107 @@
 #ifdef _WIN32
 
+#include <windows.h>
 #include <stdio.h>
+#include "raw-serial.h"
 
-struct RISC_Serial *raw_serial_new(int fd_in, int fd_out) {
-  fprintf(stderr, "The --serial-fd feature is not available on Windows.\n");
-  return NULL;
+struct RawSerial {
+  struct RISC_Serial serial;
+  HANDLE handle;
+};
+
+static uint32_t read_status(const struct RISC_Serial *serial) {
+  struct RawSerial *s = (struct RawSerial *)serial;
+  DWORD available_bytes;
+  if (!PeekNamedPipe(s->handle, 0, 0, 0, &available_bytes, 0))
+    available_bytes = 0;
+  return 2 + (available_bytes > 0);
+}
+
+static uint32_t read_data(const struct RISC_Serial *serial) {
+  if (read_status(serial) != 3) return 0;
+  struct RawSerial *s = (struct RawSerial *)serial;
+  uint8_t byte = 0;
+  DWORD numBytesRead = 0;
+  while (numBytesRead == 0) {
+    if (!ReadFile(s->handle, &byte, 1, &numBytesRead, NULL))
+      return 0;
+  }
+  return byte;
+}
+
+static void write_data(const struct RISC_Serial *serial, uint32_t data) {
+  struct RawSerial *s = (struct RawSerial *)serial;
+  uint8_t byte = (uint8_t)data;
+  DWORD numBytesWritten = 0;
+  while (numBytesWritten == 0) {
+    if (!WriteFile(s->handle, &byte, 1, &numBytesWritten, NULL))
+      return;
+  }
+}
+
+struct RISC_Serial *raw_serial_new(const char *filename_in, const char *filename_out) {
+  char pipe_name[257];
+  HANDLE file_handle;
+
+  if (strcmp(filename_out, "/dev/null") == 0) {
+    if (filename_in[0] == '\\' && strlen(filename_in) <= 256) {
+      strcpy(pipe_name, filename_in);
+    } else if (strlen(filename_in) <= 256 - 9) {
+      strcpy(pipe_name, "\\\\.\\pipe\\");
+      strcat(pipe_name, filename_in);
+    } else {
+      fprintf(stderr, "Invalid --serial-in pipe name.\n");
+      return NULL;
+    }
+    file_handle = CreateNamedPipe(pipe_name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS, 1, 256, 256, 0, NULL);
+    if (file_handle == NULL || file_handle == INVALID_HANDLE_VALUE) {
+      fprintf(stderr, "Failed to create outbound pipe instance.");
+      return NULL;
+    }
+    fprintf(stderr, "Waiting for client to connect.\n");
+    if (!ConnectNamedPipe(file_handle, NULL)) {
+      fprintf(stderr, "Failed to accept connection to named pipe.\n");
+      CloseHandle(file_handle);
+      return NULL;
+    }
+  } else if (strcmp(filename_in, "/dev/null") == 0) {
+    if (filename_out[0] == '\\' && strlen(filename_out) <= 256) {
+      strcpy(pipe_name, filename_out);
+    } else if (strlen(filename_out) <= 256 - 9) {
+      strcpy(pipe_name, "\\\\.\\pipe\\");
+      strcat(pipe_name, filename_out);
+    } else {
+      fprintf(stderr, "Invalid --serial-out pipe/device name.\n");
+      return NULL;
+    }
+    file_handle = CreateFile(pipe_name, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | SECURITY_SQOS_PRESENT | SECURITY_ANONYMOUS, NULL);
+    if (file_handle == NULL || file_handle == INVALID_HANDLE_VALUE) {
+      fprintf(stderr, "Failed to connect to pipe/device.\n");
+      return NULL;
+    }
+  } else {
+    fprintf(stderr, "On Windows, either specify --serial-out to connect to a named pipe or --serial-in to create one.\n");
+    return NULL;
+  }
+
+  struct RawSerial *s = malloc(sizeof(*s));
+  if (!s) {
+    fprintf(stderr, "Allocate structure failed.\n");
+    CloseHandle(file_handle);
+    return NULL;
+  }
+
+  *s = (struct RawSerial) {
+    .serial = {
+      .read_status = &read_status,
+      .read_data = &read_data,
+      .write_data = &write_data
+    },
+    .handle = file_handle
+  };
+
+  return &s->serial;
 }
 
 #else  // _WIN32


### PR DESCRIPTION
On Windows, named pipes work differently from POSIX. They are
bidirectional, but one side needs to create it and the other needs to
open it (similar to sockets).

Therefore, the semantics for `--serial-in` and `--serial-out` are slightly
different: Only one of them can be used at the same time. 
When `--serial-in` is used, a pipe is created, and when
`--serial-out` is used, the emulator opens the pipe/device.

If the device name does not start with a backslash, `\\.\pipe\` is
prepended, so you can use `--serial-in mypipe` instead of
`--serial-in \\.\pipe\mypipe`. In case the backslash is present, the
device name is used as is, so you should be able to use other devices
like `\\.\com4` as well (not tested due to lack of physical serial ports).

Tested with both PuTTY and another emulator at the other end of the
pipe.