### PR TITLE
Add Hardware Enumerator support

### DIFF
--- a/Mods/Clipboard.Mod
+++ b/Mods/Clipboard.Mod
@@ -1,7 +1,7 @@
 MODULE Clipboard;
   IMPORT SYSTEM, Texts, Viewers, TextFrames, Oberon;
 
-  CONST control = -24; data = -20;
+  VAR control, data: INTEGER;
 
   PROCEDURE Copy(T: Texts.Text; beg, end: INTEGER);
     VAR R: Texts.Reader;
@@ -21,7 +21,7 @@ MODULE Clipboard;
       beg, end, time: INTEGER;
   BEGIN
     Oberon.GetSelection(T, beg, end, time);
-    IF time >= 0 THEN Copy(T, beg, end) END
+    IF (time >= 0) & (data # 0) THEN Copy(T, beg, end) END
   END CopySelection;
 
   PROCEDURE CopyViewer*;
@@ -29,7 +29,7 @@ MODULE Clipboard;
       F: TextFrames.Frame;
   BEGIN
     V := Oberon.MarkedViewer();
-    IF (V # NIL) & (V.dsc # NIL) & (V.dsc.next IS TextFrames.Frame) THEN
+    IF (V # NIL) & (V.dsc # NIL) & (V.dsc.next IS TextFrames.Frame) & (data # 0) THEN
       F := V.dsc.next(TextFrames.Frame);
       Copy(F.text, 0, F.text.len)
     END
@@ -43,7 +43,7 @@ MODULE Clipboard;
       ch: CHAR;
   BEGIN
     V := Oberon.FocusViewer;
-    IF (V # NIL) & (V.dsc # NIL) & (V.dsc.next IS TextFrames.Frame) THEN
+    IF (V # NIL) & (V.dsc # NIL) & (V.dsc.next IS TextFrames.Frame) & (data # 0) THEN
       SYSTEM.GET(control, len);
       IF len > 0 THEN
         Texts.OpenWriter(W);
@@ -58,4 +58,8 @@ MODULE Clipboard;
     END
   END Paste;
 
+BEGIN
+  SYSTEM.PUT(-4, 76436C70H); (* vClp *)
+  SYSTEM.GET(-4, control);
+  SYSTEM.GET(-4, data)
 END Clipboard.

--- a/Mods/Display.Mod
+++ b/Mods/Display.Mod
@@ -191,26 +191,28 @@ MODULE Display;  (*NW 5.11.2013 / 17.1.2019*)
   END ReplPattern;
 
   PROCEDURE InitResolution;
-  VAR magic: INTEGER;
+  VAR tmp, modes, currmode: INTEGER;
   BEGIN
-    Base := 0E7F00H;
-    SYSTEM.GET(Base, magic);
-    IF magic = 53697A65H THEN
-      SYSTEM.GET(Base + 4, Width);
-      SYSTEM.GET(Base + 8, Height);
-      Span := 128;
-    ELSIF magic = 53697A66H THEN
-      SYSTEM.GET(Base + 4, Width);
-      SYSTEM.GET(Base + 8, Height);
-      Span := Width DIV 8
-    ELSIF magic = 53697A67H THEN
-      SYSTEM.GET(Base + 4, Width);
-      SYSTEM.GET(Base + 8, Height);
-      SYSTEM.GET(Base + 12, Base);
-      Span := Width DIV 8
-    ELSE
-      Width := 1024; Height := 768; Span := 128
+    SYSTEM.PUT(-4, 6D566964H); (* 'mVid' *)
+    SYSTEM.GET(-4, modes);
+    SYSTEM.GET(-4, currmode);
+    IF (currmode # 0) & (modes # 1) THEN
+      SYSTEM.GET(currmode, tmp); currmode := tmp;
     END;
+    IF currmode < modes THEN
+      WHILE currmode > 0 DO
+        SYSTEM.GET(-4, tmp); SYSTEM.GET(-4, tmp); SYSTEM.GET(-4, tmp); SYSTEM.GET(-4, tmp); DEC(currmode)
+      END;
+      SYSTEM.GET(-4, Width);
+      SYSTEM.GET(-4, Height);
+      SYSTEM.GET(-4, Span);
+      SYSTEM.GET(-4, Base);
+    ELSE
+      Base := 0E7F00H;
+      Width := 1024;
+      Height := 768;
+      Span := 128
+    END
   END InitResolution;
 
 BEGIN InitResolution;


### PR DESCRIPTION
Hardware Enumerator is a way for a running Oberon system to obtain information about the hardware (or emulator) it runs on.

See <https://github.com/schierlm/OberonEmulator/blob/master/hardware-enumerator.md>.

Also update `Display.Mod` and `Clipboard.Mod` to use it.